### PR TITLE
Add Godot project skeleton and main menu

### DIFF
--- a/data/modules.json
+++ b/data/modules.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "example",
+    "name": "Example Module"
+  }
+]

--- a/main/Main.gd
+++ b/main/Main.gd
@@ -1,0 +1,4 @@
+extends Node
+
+func _ready():
+    pass

--- a/main/Main.tscn
+++ b/main/Main.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://ui/MainMenu.tscn" type="PackedScene" id=1]
+[ext_resource path="res://main/Main.gd" type="Script" id=2]
+
+[node name="Main" type="Node" script=ExtResource(2)]
+
+[node name="MainMenu" parent="." instance=ExtResource(1)]

--- a/modules/example/Example.tscn
+++ b/modules/example/Example.tscn
@@ -1,0 +1,3 @@
+[gd_scene load_steps=1 format=3]
+
+[node name="Example" type="Node"]

--- a/modules/example/metadata.json
+++ b/modules/example/metadata.json
@@ -1,0 +1,4 @@
+{
+  "name": "Example Module",
+  "description": "An example game mechanic"
+}

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,7 @@
+; Engine configuration file for Godot Engine
+config_version=5
+
+[application]
+config/name="Game Mechanics Hub"
+run/main_scene="res://main/Main.tscn"
+

--- a/ui/MainMenu.gd
+++ b/ui/MainMenu.gd
@@ -13,7 +13,7 @@ func _on_load_module():
     print("Load Module clicked")
 
 func _on_view_all_modules():
-    print("View All Modules clicked")
+    get_tree().change_scene_to_file("res://ui/ViewModules.tscn")
 
 func _on_settings():
     print("Settings clicked")

--- a/ui/MainMenu.gd
+++ b/ui/MainMenu.gd
@@ -1,0 +1,19 @@
+extends Control
+
+func _ready():
+    $VBoxContainer/NewModuleButton.pressed.connect(_on_new_module)
+    $VBoxContainer/LoadModuleButton.pressed.connect(_on_load_module)
+    $VBoxContainer/ViewAllModulesButton.pressed.connect(_on_view_all_modules)
+    $VBoxContainer/SettingsButton.pressed.connect(_on_settings)
+
+func _on_new_module():
+    print("New Module clicked")
+
+func _on_load_module():
+    print("Load Module clicked")
+
+func _on_view_all_modules():
+    print("View All Modules clicked")
+
+func _on_settings():
+    print("Settings clicked")

--- a/ui/MainMenu.tscn
+++ b/ui/MainMenu.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://ui/MainMenu.gd" type="Script" id=1]
+
+[node name="MainMenu" type="Control" script=ExtResource(1)]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="NewModuleButton" type="Button" parent="VBoxContainer"]
+text = "New Module"
+
+[node name="LoadModuleButton" type="Button" parent="VBoxContainer"]
+text = "Load Module"
+
+[node name="ViewAllModulesButton" type="Button" parent="VBoxContainer"]
+text = "View All Modules"
+
+[node name="SettingsButton" type="Button" parent="VBoxContainer"]
+text = "Settings"

--- a/ui/ViewModules.gd
+++ b/ui/ViewModules.gd
@@ -1,0 +1,31 @@
+extends Control
+
+@onready var list_container = $ScrollContainer/VBoxContainer
+
+func _ready():
+    var modules_dir = "res://modules"
+    var dir = DirAccess.open(modules_dir)
+    if dir:
+        dir.list_dir_begin()
+        var entry = dir.get_next()
+        while entry != "":
+            if dir.current_is_dir():
+                var metadata_path = modules_dir + "/" + entry + "/metadata.json"
+                if FileAccess.file_exists(metadata_path):
+                    var file = FileAccess.open(metadata_path, FileAccess.READ)
+                    if file:
+                        var data = JSON.parse_string(file.get_as_text())
+                        if typeof(data) == TYPE_DICTIONARY:
+                            var name = data.get("name", entry)
+                            var status = data.get("status", "Unknown")
+                            var tags = data.get("tags", [])
+                            var tags_text = ""
+                            if tags is Array:
+                                tags_text = ", ".join(tags)
+                            else:
+                                tags_text = str(tags)
+                            var label = Label.new()
+                            label.text = "%s - %s - %s" % [name, status, tags_text]
+                            list_container.add_child(label)
+            entry = dir.get_next()
+        dir.list_dir_end()

--- a/ui/ViewModules.tscn
+++ b/ui/ViewModules.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://ui/ViewModules.gd" type="Script" id=1]
+
+[node name="ViewModules" type="Control" script=ExtResource(1)]
+
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+size_flags_horizontal = 3
+size_flags_vertical = 3


### PR DESCRIPTION
## Summary
- add Godot project file and default scene
- scaffold directories for modules, data and main menu UI
- implement MainMenu with placeholder button actions
- include example module and data entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686277e20f44832ab8ae0083c2937b45