### PR TITLE
Add ViewModules scene and hook up main menu

### DIFF
--- a/ui/MainMenu.gd
+++ b/ui/MainMenu.gd
@@ -13,7 +13,7 @@ func _on_load_module():
     print("Load Module clicked")
 
 func _on_view_all_modules():
-    print("View All Modules clicked")
+    get_tree().change_scene_to_file("res://ui/ViewModules.tscn")
 
 func _on_settings():
     print("Settings clicked")

--- a/ui/ViewModules.gd
+++ b/ui/ViewModules.gd
@@ -1,0 +1,31 @@
+extends Control
+
+@onready var list_container = $ScrollContainer/VBoxContainer
+
+func _ready():
+    var modules_dir = "res://modules"
+    var dir = DirAccess.open(modules_dir)
+    if dir:
+        dir.list_dir_begin()
+        var entry = dir.get_next()
+        while entry != "":
+            if dir.current_is_dir():
+                var metadata_path = modules_dir + "/" + entry + "/metadata.json"
+                if FileAccess.file_exists(metadata_path):
+                    var file = FileAccess.open(metadata_path, FileAccess.READ)
+                    if file:
+                        var data = JSON.parse_string(file.get_as_text())
+                        if typeof(data) == TYPE_DICTIONARY:
+                            var name = data.get("name", entry)
+                            var status = data.get("status", "Unknown")
+                            var tags = data.get("tags", [])
+                            var tags_text = ""
+                            if tags is Array:
+                                tags_text = ", ".join(tags)
+                            else:
+                                tags_text = str(tags)
+                            var label = Label.new()
+                            label.text = "%s - %s - %s" % [name, status, tags_text]
+                            list_container.add_child(label)
+            entry = dir.get_next()
+        dir.list_dir_end()

--- a/ui/ViewModules.tscn
+++ b/ui/ViewModules.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://ui/ViewModules.gd" type="Script" id=1]
+
+[node name="ViewModules" type="Control" script=ExtResource(1)]
+
+[node name="ScrollContainer" type="ScrollContainer" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ScrollContainer"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+size_flags_horizontal = 3
+size_flags_vertical = 3


### PR DESCRIPTION
## Summary
- create `ViewModules.tscn` scene with a `ScrollContainer` and `VBoxContainer`
- implement `ViewModules.gd` to load module metadata and populate the list
- load the new scene from the main menu when "View All Modules" is pressed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68628a586afc832abe3fb1dec9abc1ca