### PR TITLE
Implement main menu screens

### DIFF
--- a/modules/example/Example.tscn
+++ b/modules/example/Example.tscn
@@ -1,3 +1,6 @@
-[gd_scene load_steps=1 format=3]
+[gd_scene load_steps=2 format=3]
 
-[node name="Example" type="Node"]
+[node name="Example" type="Node2D"]
+
+[node name="Label" type="Label" parent="Example"]
+text = "This is a test module"

--- a/modules/example/metadata.json
+++ b/modules/example/metadata.json
@@ -1,4 +1,8 @@
 {
-  "name": "Example Module",
-  "description": "An example game mechanic"
+  "name": "Example Mechanic",
+  "description": "A simple example module",
+  "tags": ["demo", "test"],
+  "status": "In Work",
+  "author": "System",
+  "version": "1.0"
 }

--- a/ui/LoadModule.gd
+++ b/ui/LoadModule.gd
@@ -1,0 +1,40 @@
+extends Control
+
+@onready var modules_list = $VBoxContainer/ModulesList
+
+func _ready():
+    $VBoxContainer/BackButton.pressed.connect(_on_back)
+    _populate_modules()
+
+func _populate_modules():
+    var dir = DirAccess.open("res://modules")
+    if dir:
+        dir.list_dir_begin()
+        var entry = dir.get_next()
+        while entry != "":
+            if dir.current_is_dir():
+                var metadata_path = "res://modules/" + entry + "/metadata.json"
+                var module_name = entry
+                if FileAccess.file_exists(metadata_path):
+                    var file = FileAccess.open(metadata_path, FileAccess.READ)
+                    if file:
+                        var data = JSON.parse_string(file.get_as_text())
+                        if typeof(data) == TYPE_DICTIONARY:
+                            module_name = data.get("name", entry)
+                var row = HBoxContainer.new()
+                var label = Label.new()
+                label.text = module_name
+                var button = Button.new()
+                button.text = "Load"
+                button.pressed.connect(_on_load_button.bind(entry))
+                row.add_child(label)
+                row.add_child(button)
+                modules_list.add_child(row)
+            entry = dir.get_next()
+        dir.list_dir_end()
+
+func _on_load_button(module_dir):
+    print("Load module: %s" % module_dir)
+
+func _on_back():
+    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")

--- a/ui/LoadModule.tscn
+++ b/ui/LoadModule.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://ui/LoadModule.gd" type="Script" id=1]
+
+[node name="LoadModule" type="Control" script=ExtResource(1)]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="ModulesList" type="VBoxContainer" parent="VBoxContainer"]
+size_flags_vertical = 3
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+text = "Back"

--- a/ui/MainMenu.gd
+++ b/ui/MainMenu.gd
@@ -7,13 +7,13 @@ func _ready():
     $VBoxContainer/SettingsButton.pressed.connect(_on_settings)
 
 func _on_new_module():
-    print("New Module clicked")
+    get_tree().change_scene_to_file("res://ui/NewModule.tscn")
 
 func _on_load_module():
-    print("Load Module clicked")
+    get_tree().change_scene_to_file("res://ui/LoadModule.tscn")
 
 func _on_view_all_modules():
     get_tree().change_scene_to_file("res://ui/ViewModules.tscn")
 
 func _on_settings():
-    print("Settings clicked")
+    get_tree().change_scene_to_file("res://ui/Settings.tscn")

--- a/ui/NewModule.gd
+++ b/ui/NewModule.gd
@@ -1,0 +1,46 @@
+extends Control
+
+@onready var name_edit = $VBoxContainer/NameEdit
+@onready var description_edit = $VBoxContainer/DescriptionEdit
+@onready var tags_edit = $VBoxContainer/TagsEdit
+@onready var status_dropdown = $VBoxContainer/StatusDropdown
+
+func _ready():
+    $VBoxContainer/CreateButton.pressed.connect(_on_create)
+    $VBoxContainer/BackButton.pressed.connect(_on_back)
+    status_dropdown.add_item("In Work")
+    status_dropdown.add_item("Finished")
+
+func _on_create():
+    var module_name = name_edit.text.strip_edges()
+    if module_name == "":
+        return
+    var folder_name = module_name.to_lower().replace(" ", "_")
+    var dir = DirAccess.open("res://")
+    if dir:
+        dir.make_dir("modules/" + folder_name)
+
+    var module_path = "res://modules/" + folder_name
+    var metadata = {
+        "name": module_name,
+        "description": description_edit.text,
+        "tags": tags_edit.text.split(",", false),
+        "status": status_dropdown.get_item_text(status_dropdown.selected),
+        "author": "",
+        "version": "0.1"
+    }
+    var meta_file = FileAccess.open(module_path + "/metadata.json", FileAccess.WRITE)
+    if meta_file:
+        meta_file.store_string(JSON.new().stringify(metadata, "\t"))
+        meta_file.close()
+
+    var scene_file = FileAccess.open(module_path + "/Module.tscn", FileAccess.WRITE)
+    if scene_file:
+        scene_file.store_string("[gd_scene load_steps=1 format=3]\n\n[node name=\"Module\" type=\"Node\"]")
+        scene_file.close()
+
+    print("Created module: " + module_name)
+    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")
+
+func _on_back():
+    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")

--- a/ui/NewModule.tscn
+++ b/ui/NewModule.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://ui/NewModule.gd" type="Script" id=1]
+
+[node name="NewModule" type="Control" script=ExtResource(1)]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="NameLabel" type="Label" parent="VBoxContainer"]
+text = "Module Name"
+
+[node name="NameEdit" type="LineEdit" parent="VBoxContainer"]
+
+[node name="DescriptionLabel" type="Label" parent="VBoxContainer"]
+text = "Description"
+
+[node name="DescriptionEdit" type="TextEdit" parent="VBoxContainer"]
+custom_minimum_size = Vector2(0, 100)
+
+[node name="TagsLabel" type="Label" parent="VBoxContainer"]
+text = "Tags (comma separated)"
+
+[node name="TagsEdit" type="LineEdit" parent="VBoxContainer"]
+
+[node name="StatusLabel" type="Label" parent="VBoxContainer"]
+text = "Status"
+
+[node name="StatusDropdown" type="OptionButton" parent="VBoxContainer"]
+
+[node name="CreateButton" type="Button" parent="VBoxContainer"]
+text = "Create"
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+text = "Back"

--- a/ui/Settings.gd
+++ b/ui/Settings.gd
@@ -1,0 +1,7 @@
+extends Control
+
+func _ready():
+    $VBoxContainer/BackButton.pressed.connect(_on_back)
+
+func _on_back():
+    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")

--- a/ui/Settings.tscn
+++ b/ui/Settings.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://ui/Settings.gd" type="Script" id=1]
+
+[node name="Settings" type="Control" script=ExtResource(1)]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+text = "Settings Placeholder"
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+text = "Back"

--- a/ui/ViewModules.gd
+++ b/ui/ViewModules.gd
@@ -3,6 +3,10 @@ extends Control
 @onready var list_container = $ScrollContainer/VBoxContainer
 
 func _ready():
+    $BackButton.pressed.connect(_on_back)
+    _populate()
+
+func _populate():
     var modules_dir = "res://modules"
     var dir = DirAccess.open(modules_dir)
     if dir:
@@ -29,3 +33,6 @@ func _ready():
                             list_container.add_child(label)
             entry = dir.get_next()
         dir.list_dir_end()
+
+func _on_back():
+    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")

--- a/ui/ViewModules.tscn
+++ b/ui/ViewModules.tscn
@@ -7,6 +7,7 @@
 [node name="ScrollContainer" type="ScrollContainer" parent="."]
 anchor_left = 0.0
 anchor_top = 0.0
+offset_bottom = -50
 anchor_right = 1.0
 anchor_bottom = 1.0
 
@@ -17,3 +18,11 @@ anchor_right = 1.0
 anchor_bottom = 0.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
+[node name="BackButton" type="Button" parent="."]
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_right = 0.0
+anchor_bottom = 1.0
+offset_left = 10
+offset_bottom = -10
+text = "Back"


### PR DESCRIPTION
## Summary
- expand metadata and example module
- implement New Module creation form
- implement module loading list
- add placeholder settings screen
- wire up View Modules with a back button
- update Main Menu to navigate to each screen

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628fb5b5ac832aa8edb6c4d29146bb