### PR TITLE
Fix MainMenu overlay in Main.tscn

### DIFF
--- a/main/Main.tscn
+++ b/main/Main.tscn
@@ -7,4 +7,4 @@
 
 [node name="MainScreenContainer" type="Control" parent="."]
 
-[node name="MainMenu" parent="." instance=ExtResource(1)]
+[node name="MainMenu" parent="MainScreenContainer" instance=ExtResource(1)]

--- a/ui/LoadModule.gd
+++ b/ui/LoadModule.gd
@@ -37,4 +37,4 @@ func _on_load_button(module_dir):
     print("Load module: %s" % module_dir)
 
 func _on_back():
-    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")
+    get_tree().change_scene_to_file("res://main/Main.tscn")

--- a/ui/MainMenu.gd
+++ b/ui/MainMenu.gd
@@ -17,11 +17,11 @@ func _ready() -> void:
 	print_debug("Debug: Reached _ready() in MainMenu.gd")
 	push_warning("If you see this, script is executing.")
 
-	main_screen_container = get_parent().get_node_or_null("MainScreenContainer")
-	if main_screen_container == null:
-		push_error("MainScreenContainer node not found!")
-	else:
-		print("MainScreenContainer found")
+    main_screen_container = get_parent()
+    if main_screen_container == null:
+            push_error("MainScreenContainer node not found!")
+    else:
+            print("MainScreenContainer found")
 
 	new_module_button.pressed.connect(_on_new_module)
 	load_module_button.pressed.connect(_on_load_module)

--- a/ui/NewModule.gd
+++ b/ui/NewModule.gd
@@ -40,7 +40,7 @@ func _on_create():
         scene_file.close()
 
     print("Created module: " + module_name)
-    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")
+    get_tree().change_scene_to_file("res://main/Main.tscn")
 
 func _on_back():
-    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")
+    get_tree().change_scene_to_file("res://main/Main.tscn")

--- a/ui/Settings.gd
+++ b/ui/Settings.gd
@@ -4,4 +4,4 @@ func _ready():
     $VBoxContainer/BackButton.pressed.connect(_on_back)
 
 func _on_back():
-    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")
+    get_tree().change_scene_to_file("res://main/Main.tscn")

--- a/ui/ViewModules.gd
+++ b/ui/ViewModules.gd
@@ -35,4 +35,4 @@ func _populate():
         dir.list_dir_end()
 
 func _on_back():
-    get_tree().change_scene_to_file("res://ui/MainMenu.tscn")
+    get_tree().change_scene_to_file("res://main/Main.tscn")


### PR DESCRIPTION
## Summary
- make MainMenu a child of `MainScreenContainer`
- update menu to look up the container via parent
- route back buttons through `Main.tscn`

## Testing
- `git log -1 --stat`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862a1e896bc832a8f34cf34ab7d654f