### PR TITLE
Fix MainMenu loading safety checks

### DIFF
--- a/ui/MainMenu.gd
+++ b/ui/MainMenu.gd
@@ -13,47 +13,55 @@ const SETTINGS_PATH := "res://ui/Settings.tscn"
 var main_screen_container: Control
 
 func _ready() -> void:
-	print("MainMenu is READY")
-	print_debug("Debug: Reached _ready() in MainMenu.gd")
-	push_warning("If you see this, script is executing.")
+    print("MainMenu is READY")
+    print_debug("Debug: Reached _ready() in MainMenu.gd")
 
-    main_screen_container = get_parent()
+    main_screen_container = get_node_or_null("..")
     if main_screen_container == null:
-            push_error("MainScreenContainer node not found!")
-    else:
-            print("MainScreenContainer found")
+        push_error("MainScreenContainer node not found!")
+        return
+    print("MainScreenContainer found")
 
-	new_module_button.pressed.connect(_on_new_module)
-	load_module_button.pressed.connect(_on_load_module)
-	view_modules_button.pressed.connect(_on_view_all_modules)
-	settings_button.pressed.connect(_on_settings)
+    new_module_button.pressed.connect(_on_new_module)
+    load_module_button.pressed.connect(_on_load_module)
+    view_modules_button.pressed.connect(_on_view_all_modules)
+    settings_button.pressed.connect(_on_settings)
 
 func clear_children(node: Node) -> void:
-	for child in node.get_children():
-		child.queue_free()
+    for child in node.get_children():
+        child.queue_free()
 
 func _load_into_container(scene_path: String) -> void:
-	clear_children(main_screen_container)
-	var instance = load(scene_path).instantiate()
-	main_screen_container.add_child(instance)
-	if instance is Control:
-		instance.anchor_left = 0.0
-		instance.anchor_top = 0.0
-		instance.anchor_right = 1.0
-		instance.anchor_bottom = 1.0
+    if not main_screen_container:
+        push_error("No container available to load scene: " + scene_path)
+        return
+
+    var scene_res = load(scene_path)
+    if scene_res == null or not (scene_res is PackedScene):
+        push_error("Failed to load: " + scene_path)
+        return
+
+    clear_children(main_screen_container)
+    var instance = scene_res.instantiate()
+    main_screen_container.add_child(instance)
+    if instance is Control:
+        instance.anchor_left = 0.0
+        instance.anchor_top = 0.0
+        instance.anchor_right = 1.0
+        instance.anchor_bottom = 1.0
 
 func _on_new_module() -> void:
-	print("New Module button pressed")
-	_load_into_container(NEW_MODULE_PATH)
+    print("New Module button pressed")
+    _load_into_container(NEW_MODULE_PATH)
 
 func _on_load_module() -> void:
-	print("Load Module button pressed")
-	_load_into_container(LOAD_MODULE_PATH)
+    print("Load Module button pressed")
+    _load_into_container(LOAD_MODULE_PATH)
 
 func _on_view_all_modules() -> void:
-	print("View All Modules button pressed")
-	_load_into_container(VIEW_MODULES_PATH)
+    print("View All Modules button pressed")
+    _load_into_container(VIEW_MODULES_PATH)
 
 func _on_settings() -> void:
-	print("Settings button pressed")
-	_load_into_container(SETTINGS_PATH)
+    print("Settings button pressed")
+    _load_into_container(SETTINGS_PATH)


### PR DESCRIPTION
## Summary
- ensure container is found with `get_node_or_null("..")`
- guard scene loading with null checks and proper errors
- tidy indentation for button callbacks

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862a3e5d878832a823439c62b429f5b