### PR TITLE
Add ParanoiaModule with Godot scripts

### DIFF
--- a/paranoia_meter/AuraEffect.tres
+++ b/paranoia_meter/AuraEffect.tres
@@ -1,0 +1,16 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3]
+shader = Shader.new()
+shader.code = """
+shader_type canvas_item;
+
+uniform float level = 0.0;
+
+void fragment() {
+    vec2 center = vec2(0.5);
+    float dist = distance(UV, center);
+    float aura = smoothstep(0.3, 0.5, dist);
+    vec3 base = mix(vec3(0.9), vec3(0.1), level);
+    float alpha = aura * level;
+    COLOR = vec4(base, alpha);
+}
+"""

--- a/paranoia_meter/DebugConsole.gd
+++ b/paranoia_meter/DebugConsole.gd
@@ -1,0 +1,44 @@
+extends CanvasLayer
+
+func _ready():
+    print("DebugConsole ready")
+
+func _on_Gunshot_pressed():
+    var p = get_parent()
+    if p:
+        p.change_paranoia(20)
+
+func _on_Alone_pressed():
+    var p = get_parent()
+    if p:
+        p.change_paranoia(10)
+
+func _on_Pills_pressed():
+    var p = get_parent()
+    if p:
+        p.change_paranoia(-20)
+
+func _on_Tea_pressed():
+    var p = get_parent()
+    if p:
+        p.change_paranoia(-10)
+
+func _on_DarkForest_toggled(pressed: bool):
+    var p = get_parent()
+    if p:
+        p.dark_forest = pressed
+        if pressed:
+            var lush = get_node_or_null("Panel/VBoxContainer/Lush Green")
+            if lush:
+                lush.button_pressed = false
+            p.lush_green = false
+
+func _on_LushGreen_toggled(pressed: bool):
+    var p = get_parent()
+    if p:
+        p.lush_green = pressed
+        if pressed:
+            var dark = get_node_or_null("Panel/VBoxContainer/Dark Forest")
+            if dark:
+                dark.button_pressed = false
+            p.dark_forest = false

--- a/paranoia_meter/DebugConsole.tscn
+++ b/paranoia_meter/DebugConsole.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=2 format=3]
+
+[node name="DebugConsole" type="CanvasLayer"]
+script = ExtResource( 1 )
+visible = false
+
+[node name="Panel" type="Panel" parent="."]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+
+[node name="Gunshot (+20)" type="Button" parent="Panel/VBoxContainer"]
+text = "Gunshot (+20)"
+
+[node name="Alone Too Long (+10)" type="Button" parent="Panel/VBoxContainer"]
+text = "Alone Too Long (+10)"
+
+[node name="Calming Pills (-20)" type="Button" parent="Panel/VBoxContainer"]
+text = "Calming Pills (-20)"
+
+[node name="Warm Tea (-10)" type="Button" parent="Panel/VBoxContainer"]
+text = "Warm Tea (-10)"
+
+[node name="Dark Forest" type="CheckBox" parent="Panel/VBoxContainer"]
+text = "Dark Forest"
+
+[node name="Lush Green" type="CheckBox" parent="Panel/VBoxContainer"]
+text = "Lush Green"
+
+[ext_resource path="res://paranoia_meter/DebugConsole.gd" type="Script" id=1]

--- a/paranoia_meter/ParanoiaMeter.gd
+++ b/paranoia_meter/ParanoiaMeter.gd
@@ -1,0 +1,76 @@
+extends Node2D
+
+var aura
+var debug_console
+
+var paranoia := 0.0
+var max_paranoia := 100.0
+var decay_timer := 0.0
+var base_decay := -1.0
+var decay_interval := 5.0
+var dark_forest := false
+var lush_green := false
+
+func _ready():
+    aura = get_node_or_null("AuraEffect")
+    debug_console = get_node_or_null("DebugConsole")
+    if aura:
+        print("ParanoiaMeter: AuraEffect found")
+    else:
+        print("ParanoiaMeter: AuraEffect missing")
+    if debug_console:
+        print("ParanoiaMeter: DebugConsole found")
+    else:
+        print("ParanoiaMeter: DebugConsole missing")
+    if debug_console:
+        _connect_debug_console_signals(debug_console)
+        debug_console.visible = false
+    print("ParanoiaMeter ready")
+
+func _connect_debug_console_signals(dc):
+    var vb = dc.get_node_or_null("Panel/VBoxContainer")
+    if not vb:
+        return
+    var gun = vb.get_node_or_null("Gunshot (+20)")
+    if gun:
+        gun.pressed.connect(dc._on_Gunshot_pressed)
+    var alone = vb.get_node_or_null("Alone Too Long (+10)")
+    if alone:
+        alone.pressed.connect(dc._on_Alone_pressed)
+    var pills = vb.get_node_or_null("Calming Pills (-20)")
+    if pills:
+        pills.pressed.connect(dc._on_Pills_pressed)
+    var tea = vb.get_node_or_null("Warm Tea (-10)")
+    if tea:
+        tea.pressed.connect(dc._on_Tea_pressed)
+    var df = vb.get_node_or_null("Dark Forest")
+    if df:
+        df.toggled.connect(dc._on_DarkForest_toggled)
+    var lg = vb.get_node_or_null("Lush Green")
+    if lg:
+        lg.toggled.connect(dc._on_LushGreen_toggled)
+
+func _process(delta: float) -> void:
+    decay_timer += delta
+    if decay_timer >= decay_interval:
+        decay_timer = 0.0
+        var change = base_decay
+        if dark_forest:
+            change = 5.0
+        if lush_green:
+            change = -5.0
+        change_paranoia(change)
+
+func change_paranoia(amount: float) -> void:
+    paranoia = clamp(paranoia + amount, 0.0, max_paranoia)
+    update_aura()
+    print("Paranoia changed to: ", paranoia)
+
+func update_aura() -> void:
+    if aura and aura.material and aura.material.has_shader_param("level"):
+        aura.material.set_shader_param("level", paranoia / max_paranoia)
+
+func _input(event):
+    if event.is_action_pressed("ui_cancel"):
+        if debug_console:
+            debug_console.visible = !debug_console.visible

--- a/paranoia_meter/ParanoiaMeter.tscn
+++ b/paranoia_meter/ParanoiaMeter.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3]
+
+[node name="ParanoiaMeter" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="AuraEffect" type="ColorRect" parent="."]
+material = ExtResource( 2 )
+color = Color(1,1,1,0)
+
+[node name="DebugConsole" parent="." instance=ExtResource( 3 )]
+
+[ext_resource path="res://paranoia_meter/ParanoiaMeter.gd" type="Script" id=1]
+[ext_resource path="res://paranoia_meter/AuraEffect.tres" type="ShaderMaterial" id=2]
+[ext_resource path="res://paranoia_meter/DebugConsole.tscn" type="PackedScene" id=3]

--- a/paranoia_meter/meta.json
+++ b/paranoia_meter/meta.json
@@ -1,0 +1,6 @@
+{
+  "name": "Paranoia Meter",
+  "description": "Tracks player paranoia and changes screen visuals based on triggers.",
+  "tags": ["paranoia", "aura", "shader", "debug"],
+  "status": "In Work"
+}


### PR DESCRIPTION
## Summary
- add ParanoiaModule assets
- implement paranoia meter behavior with aura shader
- implement debug console UI with buttons and toggles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d12399cb8832aabddb076f42250b0