### PR TITLE
Add Paranoia Meter module

### DIFF
--- a/paranoia_meter/AuraEffect.tres
+++ b/paranoia_meter/AuraEffect.tres
@@ -1,0 +1,23 @@
+[gd_resource type="ShaderMaterial" format=3]
+
+shader = SubResource( 1 )
+
+[sub_resource type="Shader" id=1]
+shader_type canvas_item;
+
+uniform float level : hint_range(0.0,1.0) = 0.0;
+
+void fragment() {
+    vec2 center = vec2(0.5);
+    float dist = distance(UV, center);
+    float halo = smoothstep(0.3, 0.8, dist);
+    float flicker = 0.0;
+    if (level > 0.75) {
+        flicker = (sin(UV.x * 40.0 + TIME * 10.0) + sin(UV.y * 30.0 + TIME * 8.0)) * 0.05;
+    }
+    vec4 low = vec4(0.8, 0.8, 0.8, 1.0);
+    vec4 high = vec4(0.2, 0.2, 0.2, 1.0);
+    vec4 aura_color = mix(low, high, level);
+    float intensity = clamp(level * halo + flicker, 0.0, 1.0);
+    COLOR = mix(vec4(0.0,0.0,0.0,0.0), aura_color, intensity);
+}

--- a/paranoia_meter/DebugConsole.gd
+++ b/paranoia_meter/DebugConsole.gd
@@ -1,0 +1,64 @@
+extends CanvasLayer
+
+func _ready():
+    print("DebugConsole ready")
+    var panel = get_node_or_null("Panel")
+    if panel:
+        var vbox = panel.get_node_or_null("VBoxContainer")
+        if vbox:
+            vbox.get_node("Gunshot").pressed.connect(_on_gunshot)
+            vbox.get_node("Alone").pressed.connect(_on_alone)
+            vbox.get_node("CalmingPills").pressed.connect(_on_pills)
+            vbox.get_node("WarmTea").pressed.connect(_on_tea)
+            vbox.get_node("DarkForest").toggled.connect(_on_dark_forest)
+            vbox.get_node("LushGreen").toggled.connect(_on_lush_green)
+        else:
+            print("VBoxContainer not found")
+    else:
+        print("Panel not found")
+
+func _on_gunshot():
+    var parent = get_parent()
+    if parent:
+        parent.change_paranoia(20)
+        print("Gunshot button pressed")
+
+func _on_alone():
+    var parent = get_parent()
+    if parent:
+        parent.change_paranoia(10)
+        print("Alone button pressed")
+
+func _on_pills():
+    var parent = get_parent()
+    if parent:
+        parent.change_paranoia(-20)
+        print("Calming pills button pressed")
+
+func _on_tea():
+    var parent = get_parent()
+    if parent:
+        parent.change_paranoia(-10)
+        print("Warm tea button pressed")
+
+func _on_dark_forest(button_pressed: bool):
+    var parent = get_parent()
+    if parent:
+        parent.dark_forest = button_pressed
+        if button_pressed:
+            parent.lush_green = false
+            var cb = $Panel/VBoxContainer/LushGreen
+            if cb:
+                cb.button_pressed = false
+    print("Dark forest toggled: ", button_pressed)
+
+func _on_lush_green(button_pressed: bool):
+    var parent = get_parent()
+    if parent:
+        parent.lush_green = button_pressed
+        if button_pressed:
+            parent.dark_forest = false
+            var cb = $Panel/VBoxContainer/DarkForest
+            if cb:
+                cb.button_pressed = false
+    print("Lush green toggled: ", button_pressed)

--- a/paranoia_meter/DebugConsole.tscn
+++ b/paranoia_meter/DebugConsole.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://paranoia_meter/DebugConsole.gd" type="Script" id=1]
+
+[node name="DebugConsole" type="CanvasLayer"]
+script = ExtResource( 1 )
+
+[node name="Panel" type="Panel" parent="."]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+
+[node name="Gunshot" type="Button" parent="Panel/VBoxContainer"]
+text = "Gunshot (+20)"
+
+[node name="Alone" type="Button" parent="Panel/VBoxContainer"]
+text = "Alone (+10)"
+
+[node name="CalmingPills" type="Button" parent="Panel/VBoxContainer"]
+text = "Calming Pills (-20)"
+
+[node name="WarmTea" type="Button" parent="Panel/VBoxContainer"]
+text = "Warm Tea (-10)"
+
+[node name="DarkForest" type="CheckBox" parent="Panel/VBoxContainer"]
+text = "Dark Forest"
+
+[node name="LushGreen" type="CheckBox" parent="Panel/VBoxContainer"]
+text = "Lush Green"

--- a/paranoia_meter/ParanoiaMeter.gd
+++ b/paranoia_meter/ParanoiaMeter.gd
@@ -1,0 +1,43 @@
+extends Node2D
+
+var paranoia: float = 0.0
+var dark_forest: bool = false
+var lush_green: bool = false
+
+var _timer: float = 0.0
+
+func _ready():
+    print("ParanoiaMeter ready")
+    var console = get_node_or_null("DebugConsole")
+    if console:
+        console.visible = false
+    else:
+        print("DebugConsole not found")
+
+func _process(delta: float) -> void:
+    _timer += delta
+    if _timer >= 5.0:
+        change_paranoia(-1)
+        if dark_forest:
+            change_paranoia(5)
+        if lush_green:
+            change_paranoia(-5)
+        _timer = 0.0
+    update_shader()
+
+func _input(event):
+    if event is InputEventKey and event.pressed and event.keycode == Key.F1:
+        var console = get_node_or_null("DebugConsole")
+        if console:
+            console.visible = not console.visible
+            print("Debug console toggled ", console.visible)
+
+func change_paranoia(amount: float) -> void:
+    paranoia = clamp(paranoia + amount, 0.0, 100.0)
+    print("Paranoia changed by", amount, "new value", paranoia)
+    update_shader()
+
+func update_shader():
+    var aura = get_node_or_null("AuraEffect")
+    if aura and aura.material:
+        aura.material.set_shader_parameter("level", paranoia / 100.0)

--- a/paranoia_meter/ParanoiaMeter.tscn
+++ b/paranoia_meter/ParanoiaMeter.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://paranoia_meter/ParanoiaMeter.gd" type="Script" id=1]
+[ext_resource path="res://paranoia_meter/AuraEffect.tres" type="ShaderMaterial" id=2]
+[ext_resource path="res://paranoia_meter/DebugConsole.tscn" type="PackedScene" id=3]
+
+[node name="ParanoiaMeter" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="AuraEffect" type="ColorRect" parent="."]
+material = ExtResource( 2 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(1,1,1,0)
+
+[node name="DebugConsole" parent="." instance=ExtResource(3)]

--- a/paranoia_meter/meta.json
+++ b/paranoia_meter/meta.json
@@ -1,0 +1,6 @@
+{
+  "name": "Paranoia Meter",
+  "description": "A paranoia simulation mechanic with visual aura and debug interface.",
+  "tags": ["paranoia", "aura", "shader", "module"],
+  "status": "In Work"
+}


### PR DESCRIPTION
## Summary
- add a Godot paranoia meter module
- implement paranoia logic, aura effect shader and debug console
- include meta definition for the module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d15d68214832aad1b963e6ed3fd14