### PR TITLE
Add Paranoia Meter module

### DIFF
--- a/modules/paranoia_meter/AuraEffect.shader
+++ b/modules/paranoia_meter/AuraEffect.shader
@@ -1,0 +1,23 @@
+shader_type canvas_item;
+
+uniform float level : hint_range(0.0, 1.0) = 0.0;
+
+void fragment() {
+    vec2 uv = SCREEN_UV;
+    vec2 center = vec2(0.5);
+    float dist = distance(uv, center);
+    float glow = smoothstep(0.2, 0.5, dist) * level;
+
+    vec3 col;
+    if (level < 0.25) {
+        col = vec3(0.75); // light gray
+    } else if (level < 0.5) {
+        col = vec3(0.5); // medium gray
+    } else if (level < 0.75) {
+        col = vec3(0.25); // dark gray
+    } else {
+        float flicker = sin(TIME * 20.0) * 0.05;
+        col = vec3(0.1 + flicker); // darkest with flicker
+    }
+    COLOR = vec4(col * glow, glow);
+}

--- a/modules/paranoia_meter/AuraEffect.tres
+++ b/modules/paranoia_meter/AuraEffect.tres
@@ -1,0 +1,7 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3]
+
+[ext_resource path="res://modules/paranoia_meter/AuraEffect.shader" type="Shader" id=1]
+
+[resource]
+shader = ExtResource(1)
+

--- a/modules/paranoia_meter/DebugConsole.gd
+++ b/modules/paranoia_meter/DebugConsole.gd
@@ -1,0 +1,50 @@
+extends CanvasLayer
+
+@onready var gunshot_button: Button = $Panel/VBoxContainer/GunshotButton
+@onready var alone_button: Button = $Panel/VBoxContainer/AloneButton
+@onready var calming_pills_button: Button = $Panel/VBoxContainer/CalmingPillsButton
+@onready var warm_tea_button: Button = $Panel/VBoxContainer/WarmTeaButton
+@onready var dark_forest_check: CheckBox = $Panel/VBoxContainer/DarkForest
+@onready var lush_green_check: CheckBox = $Panel/VBoxContainer/LushGreen
+
+func _ready() -> void:
+    print("DebugConsole ready")
+    gunshot_button.pressed.connect(_on_gunshot)
+    alone_button.pressed.connect(_on_alone)
+    calming_pills_button.pressed.connect(_on_pills)
+    warm_tea_button.pressed.connect(_on_tea)
+    dark_forest_check.toggled.connect(_on_dark_forest)
+    lush_green_check.toggled.connect(_on_lush_green)
+
+func _trigger(amount: int) -> void:
+    var parent_scene = get_parent()
+    if parent_scene and parent_scene.has_method("change_paranoia"):
+        parent_scene.change_paranoia(amount)
+    else:
+        push_warning("Parent scene missing change_paranoia")
+
+func _on_gunshot() -> void:
+    _trigger(20)
+
+func _on_alone() -> void:
+    _trigger(10)
+
+func _on_pills() -> void:
+    _trigger(-20)
+
+func _on_tea() -> void:
+    _trigger(-10)
+
+func _on_dark_forest(pressed: bool) -> void:
+    if pressed:
+        lush_green_check.button_pressed = false
+    var parent_scene = get_parent()
+    if parent_scene and parent_scene.has_method("set_environment"):
+        parent_scene.set_environment("dark_forest", pressed)
+
+func _on_lush_green(pressed: bool) -> void:
+    if pressed:
+        dark_forest_check.button_pressed = false
+    var parent_scene = get_parent()
+    if parent_scene and parent_scene.has_method("set_environment"):
+        parent_scene.set_environment("lush_green", pressed)

--- a/modules/paranoia_meter/DebugConsole.tscn
+++ b/modules/paranoia_meter/DebugConsole.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://modules/paranoia_meter/DebugConsole.gd" type="Script" id=1]
+
+[node name="DebugConsole" type="CanvasLayer" script=ExtResource(1)]
+
+[node name="Panel" type="Panel" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.3
+anchor_bottom = 0.5
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="GunshotButton" type="Button" parent="VBoxContainer"]
+text = "Gunshot"
+
+[node name="AloneButton" type="Button" parent="VBoxContainer"]
+text = "Alone"
+
+[node name="CalmingPillsButton" type="Button" parent="VBoxContainer"]
+text = "Calming Pills"
+
+[node name="WarmTeaButton" type="Button" parent="VBoxContainer"]
+text = "Warm Tea"
+
+[node name="DarkForest" type="CheckBox" parent="VBoxContainer"]
+text = "Dark Forest"
+
+[node name="LushGreen" type="CheckBox" parent="VBoxContainer"]
+text = "Lush Green"
+

--- a/modules/paranoia_meter/ParanoiaMeter.gd
+++ b/modules/paranoia_meter/ParanoiaMeter.gd
@@ -1,0 +1,45 @@
+extends Node2D
+
+@onready var aura: ColorRect = $AuraEffect
+@onready var debug_console: CanvasLayer = $DebugConsole
+@onready var decay_timer: Timer = $DecayTimer
+
+var paranoia: int = 0
+var dark_forest: bool = false
+var lush_green: bool = false
+
+func _ready() -> void:
+    print("ParanoiaMeter ready")
+    if debug_console:
+        debug_console.visible = false
+    decay_timer.timeout.connect(_on_decay_timer_timeout)
+
+func change_paranoia(amount: int) -> void:
+    paranoia = clamp(paranoia + amount, 0, 100)
+    print("Paranoia changed to " + str(paranoia))
+    if aura and aura.material:
+        aura.material.set_shader_param("level", float(paranoia) / 100.0)
+
+func set_environment(env: String, active: bool) -> void:
+    if env == "dark_forest":
+        dark_forest = active
+        if active:
+            lush_green = false
+    elif env == "lush_green":
+        lush_green = active
+        if active:
+            dark_forest = false
+
+func _on_decay_timer_timeout() -> void:
+    var delta := -1
+    if dark_forest:
+        delta += 5
+    if lush_green:
+        delta -= 5
+    change_paranoia(delta)
+
+func _input(event: InputEvent) -> void:
+    if event is InputEventKey and event.pressed and not event.echo:
+        if event.keycode == KEY_F1:
+            debug_console.visible = not debug_console.visible
+            print("Debug console toggled: " + str(debug_console.visible))

--- a/modules/paranoia_meter/ParanoiaMeter.tscn
+++ b/modules/paranoia_meter/ParanoiaMeter.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://modules/paranoia_meter/ParanoiaMeter.gd" type="Script" id=1]
+[ext_resource path="res://modules/paranoia_meter/AuraEffect.tres" type="Material" id=2]
+[ext_resource path="res://modules/paranoia_meter/DebugConsole.tscn" type="PackedScene" id=3]
+
+[node name="ParanoiaMeter" type="Node2D" script=ExtResource(1)]
+
+[node name="AuraEffect" type="ColorRect" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(1, 1, 1, 0)
+material = ExtResource(2)
+
+[node name="DebugConsole" parent="." instance=ExtResource(3)]
+
+[node name="DecayTimer" type="Timer" parent="."]
+wait_time = 5.0
+autostart = true
+one_shot = false
+

--- a/modules/paranoia_meter/meta.json
+++ b/modules/paranoia_meter/meta.json
@@ -1,0 +1,6 @@
+{
+  "name": "Paranoia Meter",
+  "description": "A paranoia simulation mechanic with visual aura and debug interface.",
+  "tags": ["paranoia", "aura", "shader", "module"],
+  "status": "In Work"
+}


### PR DESCRIPTION
## Summary
- add a paranoia meter module with debug console
- implement shader-driven aura effect
- handle paranoia events and environment states

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d17c55b00832a9128f9fb36167514