### PR TITLE
Ignore dot directories during module listing

### DIFF
--- a/ui/LoadModule.gd
+++ b/ui/LoadModule.gd
@@ -12,6 +12,9 @@ func _populate_modules():
         dir.list_dir_begin()
         var entry = dir.get_next()
         while entry != "":
+            if entry == "." or entry == "..":
+                entry = dir.get_next()
+                continue
             if dir.current_is_dir():
                 var metadata_path = "res://modules/" + entry + "/metadata.json"
                 var module_name = entry

--- a/ui/ViewModules.gd
+++ b/ui/ViewModules.gd
@@ -13,6 +13,9 @@ func _populate():
         dir.list_dir_begin()
         var entry = dir.get_next()
         while entry != "":
+            if entry == "." or entry == "..":
+                entry = dir.get_next()
+                continue
             if dir.current_is_dir():
                 var metadata_path = modules_dir + "/" + entry + "/metadata.json"
                 if FileAccess.file_exists(metadata_path):


### PR DESCRIPTION
## Summary
- skip '.' and '..' entries when populating module lists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d20cd29d0832aaff21b389ef3e714