### PR TITLE
Handle pre-existing module directories

### DIFF
--- a/ui/NewModule.gd
+++ b/ui/NewModule.gd
@@ -6,6 +6,7 @@ extends Control
 @onready var status_dropdown = $VBoxContainer/StatusDropdown
 
 func _ready():
+    print("NewModule _ready")
     $VBoxContainer/CreateButton.pressed.connect(_on_create)
     $VBoxContainer/BackButton.pressed.connect(_on_back)
     status_dropdown.add_item("In Work")
@@ -18,7 +19,15 @@ func _on_create():
     var folder_name = module_name.to_lower().replace(" ", "_")
     var dir = DirAccess.open("res://")
     if dir:
-        dir.make_dir("modules/" + folder_name)
+        if dir.dir_exists("modules/" + folder_name):
+            push_error("Module folder already exists: " + folder_name)
+            print("Module folder already exists: " + folder_name)
+            return
+        var err = dir.make_dir("modules/" + folder_name)
+        if err != OK:
+            push_error("Failed to create directory: " + folder_name)
+            print("Failed to create directory: " + folder_name)
+            return
 
     var module_path = "res://modules/" + folder_name
     var metadata = {


### PR DESCRIPTION
## Summary
- add debug print in `_ready`
- check if the target directory already exists before running `make_dir`
- report failure to create directories

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_687d3633f614832aae9a2e0813f0e94d