### PR TITLE
Update README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Godot runs the mechanic as a standalone game.
 
 When the Godot process exits, control returns to the Electron launcher.
 
+Setup
+To run the Electron launcher locally:
+
+1. Install dependencies:
+   ```
+   npm install
+   ```
+2. Start the app:
+   ```
+   npm start
+   ```
+
+This fetches all required packages and launches the development version of Game Mechanics Hub.
+
 Use Case
 The goal is to test ideas like:
 


### PR DESCRIPTION
## Summary
- add a **Setup** section to README
- document using `npm install` and `npm start`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68823c3866d0832a94057b153c3295fb