### PR TITLE
Support GODOT_PATH env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ Displays all modules in a bigger list, optionally with filters (by tag or status
 Settings
 Placeholder for global settings like Godot path or UI themes.
 
+## Configuring the Godot Path
+The launcher relies on the Godot executable to run each module. Set the `GODOT_PATH` environment variable to the full path of your Godot binary if it is not available on your system `PATH`.
+
+Example on Linux/macOS:
+
+```bash
+export GODOT_PATH=/path/to/Godot
+```
+
+On Windows (PowerShell):
+
+```powershell
+$env:GODOT_PATH = 'C:\\Path\\To\\Godot.exe'
+```
+
+If `GODOT_PATH` is not set, the app defaults to simply running `godot`.
+
 Folder Structure
 Game-Mechanics-Hub/
 ├── main.js (Electron main process)

--- a/public/script.js
+++ b/public/script.js
@@ -2,6 +2,9 @@ const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+// Allow custom Godot path via environment variable
+const godotExecutable = process.env.GODOT_PATH || 'godot';
+
 const newModuleBtn = document.getElementById('newModuleBtn');
 const loadModuleBtn = document.getElementById('loadModuleBtn');
 const viewModulesBtn = document.getElementById('viewModulesBtn');
@@ -91,8 +94,8 @@ function showModules() {
         const launchBtn = document.createElement('button');
         launchBtn.textContent = 'Launch';
         launchBtn.addEventListener('click', () => {
-            logDebug(`Attempting to load module ${folder}...`);
-            const child = spawn('godot', ['--path', moduleDir]);
+            logDebug(`Attempting to load module ${folder} using ${godotExecutable}...`);
+            const child = spawn(godotExecutable, ['--path', moduleDir]);
             child.on('close', (code) => {
                 logDebug(`Module ${folder} exited with code ${code}`);
             });


### PR DESCRIPTION
## Summary
- spawn Godot using a custom path if `GODOT_PATH` is set
- document how to configure the path in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68823c3738c4832ab62aa98c30da2c1d