### PR TITLE
Implement submenu and quit confirmation

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, dialog } = require('electron');
 const path = require('path');
 
 function createWindow() {
@@ -12,6 +12,19 @@ function createWindow() {
     });
 
     win.loadFile(path.join(__dirname, 'public', 'index.html'));
+
+    win.on('close', (e) => {
+        const choice = dialog.showMessageBoxSync(win, {
+            type: 'question',
+            buttons: ['Cancel', 'Quit'],
+            defaultId: 1,
+            cancelId: 0,
+            message: 'Are you sure you want to quit?'
+        });
+        if (choice === 0) {
+            e.preventDefault();
+        }
+    });
 }
 
 app.whenReady().then(() => {

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,8 @@
         <button id="settingsBtn">Settings</button>
     </main>
 
-    <section id="moduleList" class="hidden">
+    <section id="moduleList" class="submenu hidden">
+        <button id="backBtn" class="backBtn">Back</button>
         <h2>Modules</h2>
         <div id="modulesContainer"></div>
     </section>

--- a/public/script.js
+++ b/public/script.js
@@ -14,10 +14,12 @@ const debugPanel = document.getElementById('debugPanel');
 const debugOutput = document.getElementById('debugOutput');
 const moduleList = document.getElementById('moduleList');
 const modulesContainer = document.getElementById('modulesContainer');
+const mainMenu = document.getElementById('mainMenu');
+const backBtn = document.getElementById('backBtn');
 
 function logDebug(message) {
     const time = new Date().toLocaleTimeString();
-    debugOutput.textContent += `[${time}] ${message}\n`;
+    debugOutput.textContent += `[${time}] [DEBUG] ${message}\n`;
     debugOutput.scrollTop = debugOutput.scrollHeight;
     console.log(message);
 }
@@ -48,8 +50,15 @@ loadModuleBtn.addEventListener('click', () => {
     showModules();
 });
 
+backBtn.addEventListener('click', () => {
+    logDebug('Back to main menu');
+    moduleList.classList.add('hidden');
+    mainMenu.classList.remove('hidden');
+});
+
 function showModules() {
     moduleList.classList.remove('hidden');
+    mainMenu.classList.add('hidden');
     modulesContainer.innerHTML = '';
     const modulesPath = path.join(__dirname, '..', 'modules');
 

--- a/public/style.css
+++ b/public/style.css
@@ -18,6 +18,12 @@ button {
     margin: 5px;
     padding: 10px 15px;
 }
+.submenu {
+    padding: 20px;
+}
+.backBtn {
+    margin-bottom: 10px;
+}
 .hidden {
     display: none;
 }


### PR DESCRIPTION
## Summary
- add a Back button and submenu section
- style `.submenu` and the back button
- prefix debug logs with `[DEBUG]`
- hide main menu when showing modules
- confirm before quitting the app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68823f7b2704832a80ae343d6a366f9b