### PR TITLE
Integrate NoiseMeter module

### DIFF
--- a/public/modules.json
+++ b/public/modules.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "NoiseMeter",
+    "title": "Noise Meter",
+    "description": "Visualizes microphone noise levels in real time.",
+    "tags": ["test", "mic", "sound"],
+    "status": "In Work",
+    "path": "modules/NoiseMeter/noiseMeter.html"
+  }
+]

--- a/public/modules/NoiseMeter/noiseMeter.html
+++ b/public/modules/NoiseMeter/noiseMeter.html
@@ -5,11 +5,20 @@
     <title>Noise Meter Test</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
+        #backBtn { margin-bottom: 10px; }
+        .micWarning { color: red; font-size: 0.9em; }
         #levelBar {
             width: 0%;
             height: 20px;
             background: green;
             transition: width 0.1s linear;
+        }
+        #levelBar.active {
+            animation: pulse 0.5s linear infinite alternate;
+        }
+        @keyframes pulse {
+            from { opacity: 0.8; }
+            to { opacity: 1; }
         }
         #barContainer {
             width: 100%;
@@ -20,7 +29,9 @@
     </style>
 </head>
 <body>
+    <button onclick="history.back()" id="backBtn">&larr; Back</button>
     <h1>Noise Meter</h1>
+    <p class="micWarning">&#9888; Requires microphone access</p>
     <div id="barContainer"><div id="levelBar"></div></div>
     <p>Current level: <span id="levelNum">0</span></p>
     <button id="stopBtn" class="hidden">Stop</button>

--- a/public/modules/NoiseMeter/noiseMeter.js
+++ b/public/modules/NoiseMeter/noiseMeter.js
@@ -48,6 +48,8 @@ async function init() {
         stopBtn.classList.remove('hidden');
         stopBtn.addEventListener('click', stop);
 
+        levelBar.classList.add('active');
+
         logDebug('Noise meter started');
     } catch (err) {
         console.error('Microphone access denied or not available', err);
@@ -69,6 +71,7 @@ function stop() {
         mediaStream.getTracks().forEach(t => t.stop());
     }
     stopBtn.classList.add('hidden');
+    levelBar.classList.remove('active');
     logDebug('Noise meter stopped');
 }
 


### PR DESCRIPTION
## Summary
- add `modules.json` listing the NoiseMeter web module
- load HTML module metadata from `modules.json`
- allow opening HTML module in launcher
- add Back button and microphone warning to NoiseMeter page
- show animation on noise bar when active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688246d1b50c832aba215100e2511204