### PR TITLE
Add Voice Lock to NoiseMeter module

### DIFF
--- a/public/modules/NoiseMeter/noiseMeter.html
+++ b/public/modules/NoiseMeter/noiseMeter.html
@@ -8,8 +8,11 @@
         #backBtn { margin-bottom: 10px; }
         .micWarning { color: red; font-size: 0.9em; }
         #levelBar {
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
             width: 0%;
-            height: 20px;
             background: green;
             transition: width 0.1s linear;
         }
@@ -21,19 +24,38 @@
             to { opacity: 1; }
         }
         #barContainer {
+            position: relative;
             width: 100%;
             height: 20px;
             background: #ccc;
             margin-top: 20px;
         }
+        #targetLine {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            background: red;
+            left: 0;
+        }
+        #voiceLock p { margin: 5px 0; }
+        .hidden { display: none; }
     </style>
 </head>
 <body>
-    <button onclick="history.back()" id="backBtn">&larr; Back</button>
+    <button id="backBtn">&larr; Back</button>
     <h1>Noise Meter</h1>
     <p class="micWarning">&#9888; Requires microphone access</p>
-    <div id="barContainer"><div id="levelBar"></div></div>
+    <div id="barContainer">
+        <div id="levelBar"></div>
+        <div id="targetLine"></div>
+    </div>
     <p>Current level: <span id="levelNum">0</span></p>
+    <section id="voiceLock">
+        <p id="targetInfo"></p>
+        <p id="timerInfo"></p>
+        <p id="unlockMsg" class="hidden">&#10004; Unlocked!</p>
+    </section>
     <button id="stopBtn" class="hidden">Stop</button>
     <script src="noiseMeter.js"></script>
 </body>

--- a/public/modules/NoiseMeter/noiseMeter.js
+++ b/public/modules/NoiseMeter/noiseMeter.js
@@ -7,9 +7,21 @@ let source;
 let processor;
 let mediaStream;
 
+let micAccessGranted = false;
+let isRunning = false;
+let targetLevel = 0;
+let matchedTime = 0;
+let lastTime = 0;
+
 const levelBar = document.getElementById('levelBar');
 const levelNum = document.getElementById('levelNum');
 const stopBtn = document.getElementById('stopBtn');
+const backBtn = document.getElementById('backBtn');
+const micWarning = document.querySelector('.micWarning');
+const targetLine = document.getElementById('targetLine');
+const targetInfo = document.getElementById('targetInfo');
+const timerInfo = document.getElementById('timerInfo');
+const unlockMsg = document.getElementById('unlockMsg');
 
 function logDebug(msg) {
     if (DEBUG) {
@@ -18,9 +30,22 @@ function logDebug(msg) {
     }
 }
 
-async function init() {
+function setupGame() {
+    targetLevel = parseFloat((Math.random() * 0.35 + 0.25).toFixed(2));
+    targetLine.style.left = `${targetLevel * 100}%`;
+    targetInfo.textContent = `Target level: ${targetLevel.toFixed(2)}`;
+    timerInfo.textContent = `Matched: 0.0 / 3.0 seconds`;
+    matchedTime = 0;
+    unlockMsg.classList.add('hidden');
+}
+
+async function startCapture() {
+    if (isRunning) return;
     try {
         mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        micAccessGranted = true;
+        micWarning.classList.add('hidden');
+
         audioContext = new (window.AudioContext || window.webkitAudioContext)();
         analyser = audioContext.createAnalyser();
         analyser.fftSize = 256;
@@ -30,6 +55,7 @@ async function init() {
         source = audioContext.createMediaStreamSource(mediaStream);
         processor = audioContext.createScriptProcessor(256, 1, 1);
 
+        lastTime = performance.now();
         processor.onaudioprocess = () => {
             analyser.getByteTimeDomainData(dataArray);
             let sum = 0;
@@ -38,41 +64,79 @@ async function init() {
                 sum += v * v;
             }
             const rms = Math.sqrt(sum / dataArray.length);
-            updateDisplay(rms);
+            const adjusted = Math.min(1, rms * 2.5);
+            updateDisplay(adjusted);
         };
 
         source.connect(analyser);
         analyser.connect(processor);
         processor.connect(audioContext.destination);
 
-        stopBtn.classList.remove('hidden');
-        stopBtn.addEventListener('click', stop);
-
         levelBar.classList.add('active');
-
+        stopBtn.textContent = 'Stop';
+        stopBtn.classList.remove('hidden');
+        isRunning = true;
         logDebug('Noise meter started');
     } catch (err) {
         console.error('Microphone access denied or not available', err);
+        micWarning.classList.remove('hidden');
     }
 }
 
 function updateDisplay(level) {
+    const now = performance.now();
+    const dt = (now - lastTime) / 1000;
+    lastTime = now;
+
     const percent = Math.min(1, level) * 100;
     levelBar.style.width = `${percent}%`;
     levelNum.textContent = level.toFixed(2);
-    logDebug(`Noise level: ${level.toFixed(2)}`);
+
+    const match = Math.abs(level - targetLevel) <= 0.03;
+    levelBar.style.background = match ? 'green' : 'red';
+    if (match) {
+        matchedTime += dt;
+    }
+    timerInfo.textContent = `Matched: ${matchedTime.toFixed(1)} / 3.0 seconds`;
+    if (matchedTime >= 3 && unlockMsg.classList.contains('hidden')) {
+        unlockMsg.classList.remove('hidden');
+        stopCapture();
+        stopBtn.disabled = true;
+    }
+
+    logDebug(`Level: ${level.toFixed(2)} | Target: ${targetLevel.toFixed(2)} | Match: ${match}`);
 }
 
-function stop() {
+function stopCapture() {
+    if (!isRunning) return;
     if (processor) processor.disconnect();
     if (analyser) analyser.disconnect();
     if (source) source.disconnect();
     if (mediaStream) {
         mediaStream.getTracks().forEach(t => t.stop());
     }
-    stopBtn.classList.add('hidden');
     levelBar.classList.remove('active');
+    stopBtn.textContent = 'Resume';
+    isRunning = false;
     logDebug('Noise meter stopped');
 }
 
-window.addEventListener('DOMContentLoaded', init);
+function toggleStream() {
+    if (isRunning) {
+        stopCapture();
+    } else {
+        startCapture();
+    }
+}
+
+function back() {
+    stopCapture();
+    window.close();
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    setupGame();
+    startCapture();
+    stopBtn.addEventListener('click', toggleStream);
+    backBtn.addEventListener('click', back);
+});


### PR DESCRIPTION
## Summary
- wire up back button and stop/resume mic stream
- show microphone warning only until access granted
- normalize meter values and add toggle behavior
- implement Voice Lock mini‑game with target level and timer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688249d6bdf0832abfa606ab68543579