### PR TITLE
Add Pulse Tap rhythm mini-game

### DIFF
--- a/public/modules.json
+++ b/public/modules.json
@@ -15,4 +15,12 @@
     "status": "In Work",
     "path": "modules/VoiceLock/voiceLock.html"
   }
+  ,{
+    "name": "PulseTap",
+    "title": "Pulse Tap",
+    "description": "Tap the spacebar in time with the visual pulse.",
+    "tags": ["rhythm", "input"],
+    "status": "In Work",
+    "path": "modules/PulseTap/pulseTap.html"
+  }
 ]

--- a/public/modules/PulseTap/pulseTap.html
+++ b/public/modules/PulseTap/pulseTap.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Pulse Tap</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; text-align: center; }
+        #backBtn { margin-bottom: 10px; }
+        #pulse {
+            width: 100px;
+            height: 100px;
+            border: 3px solid #333;
+            border-radius: 50%;
+            margin: 20px auto;
+            position: relative;
+        }
+        #pulse.active {
+            animation: pulseAnim 0.2s ease-out;
+        }
+        @keyframes pulseAnim {
+            from { transform: scale(1); }
+            to { transform: scale(1.3); }
+        }
+        #result { font-size: 1.2em; margin-top: 10px; }
+        #restartBtn { margin-top: 20px; }
+        .hidden { display: none; }
+    </style>
+</head>
+<body>
+    <button id="backBtn">&larr; Back</button>
+    <h1>Pulse Tap</h1>
+    <div id="pulse"></div>
+    <p id="result">Press Space in time with the pulse</p>
+    <button id="restartBtn" class="hidden">Restart</button>
+    <script src="pulseTap.js"></script>
+</body>
+</html>

--- a/public/modules/PulseTap/pulseTap.js
+++ b/public/modules/PulseTap/pulseTap.js
@@ -1,0 +1,89 @@
+const DEBUG = true;
+
+const pulseElem = document.getElementById('pulse');
+const resultElem = document.getElementById('result');
+const restartBtn = document.getElementById('restartBtn');
+const backBtn = document.getElementById('backBtn');
+
+let beatLength = 1000; // ms
+let intervalId = null;
+let lastBeat = 0;
+let perfectStreak = 0;
+let combo = 0;
+
+window.pulseTapScore = { combo: 0 };
+
+function logDebug(msg) {
+    if (DEBUG) {
+        const t = new Date().toLocaleTimeString();
+        console.log(`[${t}] [DEBUG] ${msg}`);
+    }
+}
+
+function pulse() {
+    lastBeat = performance.now();
+    pulseElem.classList.add('active');
+    setTimeout(() => pulseElem.classList.remove('active'), 150);
+}
+
+function startGame() {
+    logDebug('Game started');
+    beatLength = 1000;
+    perfectStreak = 0;
+    combo = 0;
+    window.pulseTapScore.combo = 0;
+    resultElem.textContent = 'Press Space in time with the pulse';
+    restartBtn.classList.add('hidden');
+    clearInterval(intervalId);
+    pulse();
+    intervalId = setInterval(pulse, beatLength);
+}
+
+function adjustTempo() {
+    if (perfectStreak > 0 && perfectStreak % 5 === 0) {
+        beatLength = Math.max(300, beatLength - 100);
+        clearInterval(intervalId);
+        intervalId = setInterval(pulse, beatLength);
+        logDebug(`Tempo increased. New beat length: ${beatLength}ms`);
+    }
+}
+
+function handleKey(e) {
+    if (e.code !== 'Space') return;
+    const now = performance.now();
+    let delta = now - lastBeat;
+    if (delta > beatLength / 2) {
+        delta -= beatLength;
+    }
+    const abs = Math.abs(delta);
+    let msg = '';
+    if (abs <= 50) {
+        msg = 'Perfect!';
+        perfectStreak++;
+        combo++;
+    } else if (abs <= 100) {
+        msg = 'Good!';
+        perfectStreak = 0;
+        combo = 0;
+    } else {
+        msg = delta < 0 ? 'Too early!' : 'Too late!';
+        perfectStreak = 0;
+        combo = 0;
+    }
+    window.pulseTapScore.combo = combo;
+    resultElem.textContent = msg;
+    logDebug(`Key press delta: ${delta.toFixed(1)}ms | ${msg}`);
+    restartBtn.classList.remove('hidden');
+    adjustTempo();
+}
+
+function back() {
+    window.close();
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    startGame();
+    document.addEventListener('keydown', handleKey);
+    restartBtn.addEventListener('click', startGame);
+    backBtn.addEventListener('click', back);
+});


### PR DESCRIPTION
## Summary
- implement a simple standalone rhythm game module
- show a pulsing circle every beat
- detect spacebar presses and provide timing feedback
- allow restart and expose combo score
- register module in `modules.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68824ee8b530832a91ca03056bb959e4