### PR TITLE
Improve PulseTap rhythm visuals

### DIFF
--- a/public/modules/PulseTap/pulseTap.html
+++ b/public/modules/PulseTap/pulseTap.html
@@ -21,6 +21,19 @@
             from { transform: scale(1); }
             to { transform: scale(1.3); }
         }
+        #progressContainer {
+            width: 120px;
+            height: 8px;
+            background: #eee;
+            margin: 10px auto;
+            overflow: hidden;
+            border-radius: 4px;
+        }
+        #progress {
+            height: 100%;
+            width: 0;
+            background: #2196f3;
+        }
         #result { font-size: 1.2em; margin-top: 10px; }
         #restartBtn { margin-top: 20px; }
         .hidden { display: none; }
@@ -30,6 +43,7 @@
     <button id="backBtn">&larr; Back</button>
     <h1>Pulse Tap</h1>
     <div id="pulse"></div>
+    <div id="progressContainer"><div id="progress"></div></div>
     <p id="result">Press Space in time with the pulse</p>
     <button id="restartBtn" class="hidden">Restart</button>
     <script src="pulseTap.js"></script>

--- a/public/modules/PulseTap/pulseTap.js
+++ b/public/modules/PulseTap/pulseTap.js
@@ -1,6 +1,7 @@
 const DEBUG = true;
 
 const pulseElem = document.getElementById('pulse');
+const progressElem = document.getElementById('progress');
 const resultElem = document.getElementById('result');
 const restartBtn = document.getElementById('restartBtn');
 const backBtn = document.getElementById('backBtn');
@@ -23,7 +24,14 @@ function logDebug(msg) {
 function pulse() {
     lastBeat = performance.now();
     pulseElem.classList.add('active');
-    setTimeout(() => pulseElem.classList.remove('active'), 150);
+    // reset progress bar
+    progressElem.style.transition = 'none';
+    progressElem.style.width = '0%';
+    setTimeout(() => {
+        pulseElem.classList.remove('active');
+        progressElem.style.transition = `width ${beatLength}ms linear`;
+        progressElem.style.width = '100%';
+    }, 20);
 }
 
 function startGame() {
@@ -35,6 +43,9 @@ function startGame() {
     resultElem.textContent = 'Press Space in time with the pulse';
     restartBtn.classList.add('hidden');
     clearInterval(intervalId);
+    // start progress bar animation
+    progressElem.style.transition = `width ${beatLength}ms linear`;
+    progressElem.style.width = '100%';
     pulse();
     intervalId = setInterval(pulse, beatLength);
 }


### PR DESCRIPTION
## Summary
- add progress bar indicator to PulseTap
- animate the bar with each beat for clearer timing feedback
- verify no old NoiseMeter modules exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882534c3ac0832a93d7d94c8eee7546